### PR TITLE
Add terraform-docs integration

### DIFF
--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -1,0 +1,20 @@
+name: Terraform Docs
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/*.tf'
+      - '**/*.tfvars'
+      - '.terraform-docs.yml'
+
+jobs:
+  terraform-docs:
+    name: Update Terraform Docs
+    uses: proscia-techops/github-actions-workflows/.github/workflows/terraform-docs.yml@main
+    with:
+      working-directory: '.'
+      output-file: 'README.md'
+      output-method: 'inject'
+      git-push: true
+      config-file: '.terraform-docs.yml'

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,26 @@
+formatter: markdown table
+
+sections:
+  hide:
+    - header
+    - providers
+
+settings:
+  anchor: false
+  color: true
+  default: true
+  escape: false
+  indent: 2
+  required: true
+  sensitive: true
+  type: true
+
+sort:
+  enabled: true
+  by: name
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    {{ .Content }}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ locals {
 }
 ```
 
-## Outputs
+## Requirements
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+
+## Manual Outputs Reference
 
 | Name | Description |
 |------|-------------|


### PR DESCRIPTION
This PR adds terraform-docs integration to automatically update README.md documentation when Terraform files are changed.

## Changes
- Added terraform-docs markers to README.md
- Created .terraform-docs.yml configuration
- Added GitHub Actions workflow that uses the centralized terraform-docs workflow

This will ensure our module documentation stays up to date with code changes.