### PR TITLE
chore: add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,39 @@
+# Default: Handle line endings automatically for files detected as text
+*               text=auto
+
+# Terraform files
+*.tf            text eol=lf
+*.tfvars        text eol=lf
+.terraform.lock.hcl linguist-generated=true
+
+# Shell scripts
+*.sh            text eol=lf
+*.bash          text eol=lf
+
+# Documentation
+*.md            text diff=markdown
+LICENSE         text
+*.txt           text
+README*         text
+
+# Configs
+.gitattributes  text
+.gitignore      text
+.editorconfig   text
+*.toml          text
+*.yaml          text
+*.yml           text
+
+# Graphics and binary files
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.gif           binary
+*.ico           binary
+*.pdf           binary
+
+# Archives
+*.gz            binary
+*.zip           binary
+*.tar           binary
+*.tgz           binary


### PR DESCRIPTION
This PR adds a .gitattributes file to ensure consistent file handling, especially for line endings and binary files.

The configuration includes:
- Auto-detection of text files with proper line ending normalization
- Explicit EOL settings for Terraform files (LF)
- Marking .terraform.lock.hcl as generated
- Consistent handling of documentation and config files
- Proper binary file handling for images and archives

This helps ensure consistent file handling across different operating systems and environments.