### PR TITLE
feat: add terraform-release workflow with semantic versioning

### DIFF
--- a/.github/workflows/terraform-release.yml
+++ b/.github/workflows/terraform-release.yml
@@ -1,0 +1,36 @@
+name: Terraform Release
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.tf'
+      - '**/*.tfvars'
+      - '.github/workflows/terraform-release.yml'
+      # Don't trigger on README updates from terraform-docs
+      - '!README.md'
+    tags-ignore:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      default_bump:
+        description: 'Default version bump if none specified (major, minor, patch)'
+        required: false
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    name: Create Terraform Release
+    uses: proscia-techops/github-actions-workflows/.github/workflows/terraform-release.yml@main
+    with:
+      working-directory: '.'
+      default-bump: ${{ github.event.inputs.default_bump || 'minor' }}
+      # The centralized workflow automatically handles the following scenarios:
+      # - Commits with "feat!" or "BREAKING CHANGE" in title/body will trigger major bump
+      # - Commits with "feat" type will trigger minor bump if default is not overridden
+      # - Commits with "fix" type will trigger patch bump if default is not overridden


### PR DESCRIPTION
This PR adds a terraform-release workflow that uses the centralized workflow from the github-actions-workflows repository.

Features:
- Triggers on pushes to main that modify Terraform files
- Allows manual triggering via workflow_dispatch with selectable bump type
- Sets 'minor' as the default version bump type
- Respects semantic versioning conventions:
  - Breaking changes (feat\! or BREAKING CHANGE) trigger major version bumps
  - Feature additions trigger minor version bumps
  - Bug fixes trigger patch version bumps

This workflow will automatically create GitHub releases with proper semantic version tags when code is pushed to the main branch.